### PR TITLE
activate overlap single

### DIFF
--- a/src/evaluation.py
+++ b/src/evaluation.py
@@ -125,9 +125,9 @@ class DeconvPlot():
             pass
 
         return performance,total_x,total_y
-
     
-    def overlap_singles(self,evalxy, title_list=['Naive B','Naive CD4 T','CD8 T','NK','Monocytes']):
+    
+    def overlap_singles(self, evalxy, title_list=['Naive B','Naive CD4 T','CD8 T','NK','Monocytes']):
         total_x = []
         for t in evalxy[0]:
             total_x.extend(t)
@@ -175,7 +175,7 @@ class DeconvPlot():
         plt.show()
 
 def eval_deconv(dec_name_list=[[0],[1]], val_name_list=[["Monocytes"],["CD4Tcells"]], 
-                deconv_df=None, y_df=None):
+                deconv_df=None, y_df=None, do_plot=True, overlap=False):
     # overall
     assert len(dec_name_list) == len(val_name_list)
     tab_colors = mcolors.TABLEAU_COLORS
@@ -183,12 +183,22 @@ def eval_deconv(dec_name_list=[[0],[1]], val_name_list=[["Monocytes"],["CD4Tcell
     loop_n = len(dec_name_list) // len(color_list)
     color_list = color_list * (loop_n+1)
     overall_res = []
+
+    dec_eval_x = []
+    ref_eval_y = []
     for i in range(len(dec_name_list)):
         dec_name = dec_name_list[i]
         val_name = val_name_list[i]
-        plot_dat = DeconvPlot(deconv_df=deconv_df,val_df=y_df,dec_name=dec_name,val_name=val_name,plot_size=20,dpi=50)
+        plot_dat = DeconvPlot(deconv_df=deconv_df,val_df=y_df,dec_name=dec_name,val_name=val_name,plot_size=20,dpi=50,do_plot=do_plot)
         res = plot_dat.plot_simple_corr(color=color_list[i],title=f'Topic:{dec_name} vs {val_name}',target_samples=None)
         overall_res.append(res)
+
+        dec_eval_x.append(res[1])
+        ref_eval_y.append(res[2])
+    
+    if overlap:
+        evalxy = [dec_eval_x, ref_eval_y]
+        plot_dat.overlap_singles(evalxy=evalxy,title_list=dec_name_list)
     
     return overall_res
 


### PR DESCRIPTION
This pull request introduces enhancements to the `eval_deconv` function in `src/evaluation.py` to improve flexibility and functionality. The key changes include adding new parameters for optional plotting and overlap evaluation, as well as integrating overlap visualization logic.

### Enhancements to `eval_deconv` function:

* Added two new parameters, `do_plot` and `overlap`, to allow users to control whether plots are generated and whether overlap evaluation is performed, respectively.
* Modified the `DeconvPlot` call to pass the `do_plot` parameter, enabling conditional plotting.
* Introduced logic to compute and store evaluation results (`dec_eval_x` and `ref_eval_y`) for overlap analysis.
* Added overlap visualization functionality using the `overlap_singles` method, which is triggered when the `overlap` parameter is set to `True`.